### PR TITLE
P2fun save

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GasChromatographySystems"
 uuid = "2a17fa6e-c440-4af9-acac-c1be9e3a006f"
 authors = ["Jan Leppert <jleppert@uni-bonn.de>"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/Flowcalc.jl
+++ b/src/Flowcalc.jl
@@ -132,7 +132,9 @@ function substitute_unknown_flows_κ(sys, bal_eq)
 	return sub_bal_eq
 end
 
-function export_balance_equations_for_Mathematica(subst_bal_eq; filename="bal_eq_for_Mathematica.txt")
+function export_balance_equations_for_Mathematica(sys; filename="bal_eq_for_Mathematica.txt")
+	@variables A, P²[1:nv(sys.g)], λ[1:ne(sys.g)], F[1:ne(sys.g)]
+	subst_bal_eq = GasChromatographySystems.substitute_unknown_flows(sys)
 	# change format for Mathematica
 	bal_eq_char = collect(replace(string(subst_bal_eq), "Symbolics.Equation[" => "{", "~" => "=="))
 	bal_eq_char[end] = '}'
@@ -143,6 +145,7 @@ function export_balance_equations_for_Mathematica(subst_bal_eq; filename="bal_eq
 end
 
 function import_solution_from_Mathmatica(file)
+	@variables A, P²[1:nv(sys.g)], λ[1:ne(sys.g)], F[1:ne(sys.g)]
 	# do the Symbols have to be defined before?
 	sol_str = read(file, String)
 	# change the format for Julia

--- a/src/GasChromatographySystems.jl
+++ b/src/GasChromatographySystems.jl
@@ -519,6 +519,55 @@ function graph_to_parameters(sys, db_dataframe, selected_solutes; interp=true, d
 	end
 	return parameters
 end
+
+function graph_to_parameters(sys, p2fun, db_dataframe, selected_solutes; interp=true, dt=1, mode="λ")
+	# ng should be taken from the separat module options 
+	E = collect(edges(sys.g))
+	srcE = src.(E) # source indices
+	dstE = dst.(E) # destination indices
+	if interp == true # linear interpolation of pressure functions with step width dt
+		p_func = GasChromatographySystems.interpolate_pressure_functions(sys, p2fun; dt=dt, mode=mode)
+	else
+		p_func = GasChromatographySystems.pressure_functions(sys, p2fun; mode=mode)
+	end
+	parameters = Array{GasChromatographySimulator.Parameters}(undef, ne(sys.g))
+	for i=1:ne(sys.g)
+		# column parameters
+		col = GasChromatographySimulator.Column(sys.modules[i].L, sys.modules[i].d, [sys.modules[i].d], sys.modules[i].df, [sys.modules[i].df], sys.modules[i].sp, sys.options.gas)
+
+		# program parameters
+		time_steps, temp_steps, gf, a_gf, T_itp = GasChromatographySystems.module_temperature(sys.modules[i], sys)
+		pin_steps = if typeof(sys.pressurepoints[srcE[i]].P) <: GasChromatographySystems.PressureProgram
+			sys.pressurepoints[srcE[i]].P.pressure_steps
+		else
+			fill(sys.pressurepoints[srcE[i]].P, length(time_steps))
+		end
+		pout_steps = if typeof(sys.pressurepoints[dstE[i]].P) <: GasChromatographySystems.PressureProgram
+			sys.pressurepoints[dstE[i]].P.pressure_steps
+		else
+			fill(sys.pressurepoints[dstE[i]].P, length(time_steps))
+		end
+		pin_itp = p_func[srcE[i]]
+		pout_itp = p_func[dstE[i]]	
+		
+		prog = GasChromatographySimulator.Program(time_steps, temp_steps, pin_steps, pout_steps, gf, a_gf, T_itp, pin_itp, pout_itp)
+
+		# substance parameters
+		sub = GasChromatographySimulator.load_solute_database(db_dataframe, sys.modules[i].sp, sys.options.gas, selected_solutes, NaN.*ones(length(selected_solutes)), NaN.*ones(length(selected_solutes)))
+
+		# option parameters
+		#opt = if typeof(sys.modules[i]) == GasChromatographySystems.ModuleTM 
+		opt = GasChromatographySimulator.Options(alg=sys.modules[i].opt.alg, abstol=sys.modules[i].opt.abstol, reltol=sys.modules[i].opt.reltol, Tcontrol=sys.modules[i].opt.Tcontrol, odesys=sys.options.odesys, ng=sys.modules[i].opt.ng, vis=sys.options.vis, control=sys.options.control, k_th=sys.options.k_th)
+		#else
+			# put options for ModuleColumn in separat options structure?
+		#	GasChromatographySimulator.Options(alg=sys.modules[i].opt.alg, abstol=sys.modules[i].opt.abstol, reltol=sys.modules[i].opt.reltol, Tcontrol=sys.modules[i].opt.Tcontrol, odesys=sys.options.odesys, ng=sys.modules[i].opt.ng, vis=sys.options.vis, control=sys.options.control, k_th=sys.options.k_th)
+		#end
+
+		parameters[i] = GasChromatographySimulator.Parameters(col, prog, sub, opt)
+	end
+	return parameters
+end
+
 # end - system to parameters
 
 # begin - simulation of system
@@ -585,10 +634,37 @@ function positive_flow(sys)
 	return pos_Flow
 end
 
+function positive_flow(sys, p2fun; mode="λ")
+	F_func = flow_functions(sys, p2fun; mode=mode)
+	tend = sum(common_timesteps(sys))
+	t = 0:tend/2:tend # !!!perhaps use interval arithmatic to test, if the flow is positive over the interval 0:tend!!!???
+	#ipar = index_parameter(sys.g, path)
+	pos_Flow = Array{Bool}(undef, length(F_func))
+	for i=1:length(F_func)
+		if isempty(findall(F_func[i].(t).<=0))
+			pos_Flow[i] = true
+		else
+			pos_Flow[i] = false
+		end
+	end
+	return pos_Flow
+end
+
 function path_possible(sys, paths)
 	#F_func = flow_functions(sys)
 	i_E = index_parameter(sys.g, paths)
 	if length(i_E) == length(findall(positive_flow(sys)[i_E]))
+		possible = true
+	else
+		possible = false
+	end
+	return possible
+end
+
+function path_possible(sys, p2fun, paths; mode="λ")
+	#F_func = flow_functions(sys)
+	i_E = index_parameter(sys.g, paths)
+	if length(i_E) == length(findall(positive_flow(sys, p2fun; mode=mode)[i_E]))
 		possible = true
 	else
 		possible = false
@@ -635,6 +711,12 @@ end
 function simulate_along_paths(sys, paths, db_dataframe, selected_solutes; t₀=zeros(length(selected_solutes)), τ₀=zeros(length(selected_solutes)))
 	par_sys = graph_to_parameters(sys, db_dataframe, selected_solutes)
 	path_pos, peaklists, solutions, new_par_sys = simulate_along_paths(sys, paths, par_sys; t₀=t₀, τ₀=τ₀)
+	return path_pos, peaklists, solutions, new_par_sys
+end
+
+function simulate_along_paths(sys, p2fun, paths, db_dataframe, selected_solutes; t₀=zeros(length(selected_solutes)), τ₀=zeros(length(selected_solutes)), mode="λ")
+	par_sys = graph_to_parameters(sys, p2fun, db_dataframe, selected_solutes, mode=mode)
+	path_pos, peaklists, solutions, new_par_sys = simulate_along_paths(sys, p2fun, paths, par_sys; t₀=t₀, τ₀=τ₀, mode=mode)
 	return path_pos, peaklists, solutions, new_par_sys
 end
 
@@ -738,6 +820,108 @@ function simulate_along_paths(sys, paths, par_sys; t₀=zeros(length(par_sys[1].
 	end
 	return path_pos, peaklists, solutions, new_par_sys
 end
+
+function simulate_along_paths(sys, p2fun, paths, par_sys; t₀=zeros(length(par_sys[1].sub)), τ₀=zeros(length(par_sys[1].sub)), nτ=6, refocus=falses(ne(sys.g)), τ₀_focus=zeros(length(par_sys[1].sub)), mode="λ", kwargsTM...)
+	
+	E = collect(edges(sys.g))
+	peaklists = Array{Array{DataFrame,1}}(undef, length(paths))
+	solutions = Array{Array{Any,1}}(undef, length(paths))
+	path_pos = Array{String}(undef, length(paths))
+	new_par_sys = Array{GasChromatographySimulator.Parameters}(undef, length(par_sys))
+	visited_E = falses(length(E))
+
+	# i -> path number
+	# j -> segment/module number
+	for i=1:length(paths)
+		i_par = GasChromatographySystems.index_parameter(sys.g, paths[i])
+		if path_possible(sys, p2fun, paths[i]; mode=mode) == true
+			path_pos[i] = "path is possible"
+			peaklists_ = Array{DataFrame}(undef, length(i_par))
+			solutions_ = Array{Any}(undef, length(i_par))
+			#As_ = Array{DataFrame}(undef, length(i_par))
+			for j=1:length(i_par)
+				if (i>1) && (all(visited_E[1:i_par[j]].==true))
+					# was the segment already simulated in a previous simulated path?
+					# look in all previous paths for the correct result -> the simulation correlated to the same edge and where this edge is connected to only previouse visited edges
+					i_path = 0
+					i_edge = 0
+					for k=1:i-1 # previous paths
+						i_par_previous = GasChromatographySystems.index_parameter(sys.g, paths[k])
+						if length(i_par_previous) < j
+							j0 = length(i_par_previous)
+						else
+							j0 = j
+						end
+						if all(x->x in i_par_previous[1:j0], i_par[1:j]) == true # all edges up to j are the same between the two paths
+							i_path = k
+							i_edge = findfirst(i_par[j].==i_par_previous)
+						end
+					end
+					# re-use the results
+					peaklists_[j] = peaklists[i_path][i_edge]
+					solutions_[j] = solutions[i_path][i_edge]
+				else # new simulated segments
+					if j == 1 # first segment, directly after injection, it is assumed to be a segment of type `ModuleColumn`
+						new_par_sys[i_par[j]] = GasChromatographySystems.change_initial(par_sys[i_par[j]], t₀, τ₀)
+						peaklists_[j], solutions_[j] = GasChromatographySimulator.simulate(new_par_sys[i_par[j]])
+						peaklists_[j][!,:A] = ones(length(peaklists_[j].Name)) # add a relativ area factor, splitting of `A` at split points is not accounted for yet, is only used for the slicing of peaks at modulators
+					elseif typeof(sys.modules[i_par[j]]) == GasChromatographySystems.ModuleTM
+						# put this in a separate function
+						if refocus[i_par[j]] == true
+							τ₀=τ₀_focus
+						else
+							τ₀=peaklists_[j-1].τR # PM?
+						end
+						new_par_sys[i_par[j]], df_A = GasChromatographySystems.slicing(peaklists_[j-1], sys.modules[i_par[j]].PM, sys.modules[i_par[j]].ratio, sys.modules[i_par[j]].shift, par_sys[i_par[j]]; nτ=nτ, τ₀=τ₀, abstol=sys.modules[i_par[j]].opt.abstol, reltol=sys.modules[i_par[j]].opt.reltol, alg=sys.modules[i_par[j]].opt.alg)
+						if sys.modules[i_par[j]].opt.alg == "simplifiedTM"
+							peaklists_[j], solutions_[j] = approximate_modulator(sys.modules[i_par[j]].T, new_par_sys[i_par[j]], df_A, sys.modules[i_par[j]].PM, sys.modules[i_par[j]].ratio, sys.modules[i_par[j]].shift, sys.modules[i_par[j]].Thot)
+						else
+							sol = Array{Any}(undef, length(new_par_sys[i_par[j]].sub))
+							for i_sub=1:length(new_par_sys[i_par[j]].sub)
+								dt = sys.modules[i_par[j]].opt.dtinit
+								sol[i_sub] = GasChromatographySimulator.solving_odesystem_r(new_par_sys[i_par[j]].col, new_par_sys[i_par[j]].prog, new_par_sys[i_par[j]].sub[i_sub], new_par_sys[i_par[j]].opt; kwargsTM..., dt=dt)
+								tR = sol[i_sub].u[end][1]
+								while (fld(tR + sys.modules[i_par[j]].shift, sys.modules[i_par[j]].PM) > fld(new_par_sys[i_par[j]].sub[i_sub].t₀ + sys.modules[i_par[j]].shift, sys.modules[i_par[j]].PM) && dt > eps()) || (sol[i_sub].retcode != ReturnCode.Success && dt > eps()) # solute elutes not in the same modulation periode or the solving failed
+									dt = dt/10 # reduce initial step-width
+									dtmax = dt*1000
+									#@warn "Retention time $(tR) surpasses modulation period, t₀ = $(new_par_sys[i_par[j]].sub[i_sub].t₀), PM = $(sys.modules[i_par[j]].PM). Initial step-width dt is decreased ($(dt))."
+									sol[i_sub] = GasChromatographySimulator.solving_odesystem_r(new_par_sys[i_par[j]].col, new_par_sys[i_par[j]].prog, new_par_sys[i_par[j]].sub[i_sub], new_par_sys[i_par[j]].opt; kwargsTM..., dt=dt, dtmax=dtmax)
+									tR = sol[i_sub].u[end][1]
+								end
+								#if isnan(tR) # does not work
+								#	@warn "Simulation result is NaN. Approximate modulator."
+								#	sol[i_sub] = approximate_modulator(new_par_sys[i_par[j]], df_A, sys.modules[i_par[j]].PM, sys.modules[i_par[j]].ratio, sys.modules[i_par[j]].shift)[2][i_sub]
+								#end
+							end
+							peaklists_[j] = GasChromatographySimulator.peaklist(sol, new_par_sys[i_par[j]])
+							GasChromatographySystems.add_A_to_pl!(peaklists_[j], df_A)
+							solutions_[j] = sol
+						end
+						if maximum(peaklists_[j].τR) > sys.modules[i_par[j]].PM
+							return @warn "Peak width of focussed peaks $(maximum(peaklists_[j].τR)) > modulation period $(sys.modules[i_par[j]].PM). Simulation is aborted. alg=$(sys.modules[i_par[j]].opt.alg), T=$(sys.modules[i_par[j]].T), peaklist=$(peaklists_[j])."
+						end
+					else # ModuleColumn
+						new_par_sys[i_par[j]] = GasChromatographySystems.change_initial(par_sys[i_par[j]], peaklists_[j-1])
+						peaklists_[j], solutions_[j] = GasChromatographySimulator.simulate(new_par_sys[i_par[j]])
+						GasChromatographySystems.add_A_to_pl!(peaklists_[j], peaklists_[j-1])
+					end
+				end
+			end
+			visited_E[i_par] .= true
+			peaklists[i] = peaklists_
+			solutions[i] = solutions_
+		else # path not possible
+			neg_flow_modules = sys.modules[findall(paths[i][findall(positive_flow(sys, p2fun; mode=mode)[i_par].==false)].==edges(sys.g))]
+			str_neg_flow = "path not possible: "
+			for j=1:length(neg_flow_modules)
+				str_neg_flow = str_neg_flow*"Flow in module >$(neg_flow_modules[j].name)< becomes negative during the program. "
+			end
+			path_pos[i] = str_neg_flow
+		end
+	end
+	return path_pos, peaklists, solutions, new_par_sys
+end
+
 
 function simulate_along_one_path(sys, path, par_sys; t₀=zeros(length(par_sys[1].sub)), τ₀=zeros(length(par_sys[1].sub)), nτ=6, refocus=falses(length(par_sys[1].sub)), τ₀_focus=zeros(length(par_sys[1].sub)), pl_thread=true, kwargsTM...)
 	

--- a/src/Structures.jl
+++ b/src/Structures.jl
@@ -369,5 +369,5 @@ struct System
 	pressurepoints::Array{PressurePoint}
 	modules::Array{AbstractModule}
 	options::Options
-	System(g_,pressurepoints_,modules_,options_) = nv(g_)!=length(pressurepoints_) || ne(g_)!=length(modules_) ? error("Mismatch between number of nodes ($(nv(g_))) and number of pressure points ($(length(pressurepoints_))) and/or mismatch between number of edges ($(ne(g_))) and number of modules ($(length(modules_))).") : new(g_,pressurepoints_,modules_,options_)
+	System(name_, g_,pressurepoints_,modules_,options_) = nv(g_)!=length(pressurepoints_) || ne(g_)!=length(modules_) ? error("Mismatch between number of nodes ($(nv(g_))) and number of pressure points ($(length(pressurepoints_))) and/or mismatch between number of edges ($(ne(g_))) and number of modules ($(length(modules_))).") : new(name_, g_,pressurepoints_,modules_,options_)
 end

--- a/src/Structures.jl
+++ b/src/Structures.jl
@@ -316,6 +316,7 @@ end
 Structure describing a GC system. 
 
 # Arguments
+* `name`: Name of the GC system.
 * `g`: The graph representation of the GC system, using `SimpleDiGraph` from `Graphs.jl`. 
 * `pressurepoints`: The vertices of graph `g` and their pressure programs. These are structures of type `PressurePoint`. 
 * `modules`: The edges of graph `g`. These are column segments of type `ModuleColumn` or thermal modulator points of type `ModuleTM`.
@@ -363,6 +364,7 @@ Definition of the graph:
 
 """
 struct System
+	name::String  # Name for the system, can be empty
 	g::Graphs.SimpleDiGraph{Int}
 	pressurepoints::Array{PressurePoint}
 	modules::Array{AbstractModule}

--- a/src/Systems.jl
+++ b/src/Systems.jl
@@ -1,7 +1,7 @@
 # definition of specific example systems
 
 # begin - specific systems
-function SeriesSystem(Ls, ds, dfs, sps, TPs, F, pin, pout; opt=GasChromatographySystems.Options(), kwargs...)
+function SeriesSystem(Ls, ds, dfs, sps, TPs, F, pin, pout; name="SeriesSystem", opt=GasChromatographySystems.Options(), kwargs...)
 	# add test for correct lengths of input
 	# ? make two versions
 	# 1. defining flow over the columns (calculate pin)
@@ -45,20 +45,20 @@ function SeriesSystem(Ls, ds, dfs, sps, TPs, F, pin, pout; opt=GasChromatography
 		end
 	end
 	# system
-	sys = GasChromatographySystems.update_system(GasChromatographySystems.System(g, pp, modules, opt))
+	sys = GasChromatographySystems.update_system(GasChromatographySystems.System(name, g, pp, modules, opt))
 
 	# add test for the defined pressures and flows
 	return sys
 end
 
-function SeriesSystem(; Ls = [10.0, 5.0, 2.0, 1.0], ds = [0.53, 0.32, 0.25, 0.1], dfs = [0.53, 0.32, 0.25, 0.1], sps = ["Rxi17SilMS", "Rxi17SilMS", "Rxi17SilMS", "Rxi17SilMS"], TPs = [default_TP(), default_TP(), default_TP(), default_TP()], F = NaN, pin = default_PP(), pout = 0.0, opt=GasChromatographySystems.Options(), kwargs...)
-	sys = SeriesSystem(Ls, ds, dfs, sps, TPs, F, pin, pout; opt=opt, kwargs...)
+function SeriesSystem(; Ls = [10.0, 5.0, 2.0, 1.0], ds = [0.53, 0.32, 0.25, 0.1], dfs = [0.53, 0.32, 0.25, 0.1], sps = ["Rxi17SilMS", "Rxi17SilMS", "Rxi17SilMS", "Rxi17SilMS"], TPs = [default_TP(), default_TP(), default_TP(), default_TP()], F = NaN, pin = default_PP(), pout = 0.0, name="SeriesSystem", opt=GasChromatographySystems.Options(), kwargs...)
+	sys = SeriesSystem(Ls, ds, dfs, sps, TPs, F, pin, pout; name=name, opt=opt, kwargs...)
 	return sys
 end
 
 #example_SeriesSystem() = SeriesSystem([10.0, 5.0, 2.0, 1.0], [0.53, 0.32, 0.25, 0.1], [0.53, 0.32, 0.25, 0.1], ["Rxi17SilMS", "Rxi17SilMS", "Rxi17SilMS", "Rxi17SilMS"], [default_TP(), default_TP(), default_TP(), default_TP()], NaN, 300.0, 0.0)
 
-function SplitSystem(Ls, ds, dfs, sps, TPs, Fs, pin, pout1, pout2; opt=GasChromatographySystems.Options(), kwargs...)
+function SplitSystem(Ls, ds, dfs, sps, TPs, Fs, pin, pout1, pout2; name="SplitSystem", opt=GasChromatographySystems.Options(), kwargs...)
 	g = SimpleDiGraph(4)
 	add_edge!(g, 1, 2) # Inj -> GC column -> Split point
 	add_edge!(g, 2, 3) # Split point -> TL column -> Det 1
@@ -97,19 +97,19 @@ function SplitSystem(Ls, ds, dfs, sps, TPs, Fs, pin, pout1, pout2; opt=GasChroma
 	modules[2] = GasChromatographySystems.ModuleColumn("2 -> 3", Ls[2], ds[2]*1e-3, dfs[2]*1e-6, sps[2], TPs[2], Fs[2]/60e6; kwargs...)
 	modules[3] = GasChromatographySystems.ModuleColumn("2 -> 4", Ls[3], ds[3]*1e-3, dfs[3]*1e-6, sps[3], TPs[3], Fs[3]/60e6; kwargs...)
 	# system
-	sys = GasChromatographySystems.update_system(GasChromatographySystems.System(g, pp, modules, opt))
+	sys = GasChromatographySystems.update_system(GasChromatographySystems.System(name, g, pp, modules, opt))
 
 	# add test for the defined pressures and flows
 	return sys
 end
 
-function SplitSystem(; Ls = [10.0, 1.0, 5.0], ds = [0.25, 0.1, 0.25], dfs = [0.25, 0.0, 0.0], sps = ["Rxi17SilMS", "", ""], TPs = [default_TP(), 300.0, 300.0], Fs = [1.0, NaN, NaN], pin = NaN, pout1 = 0.0, pout2 = 101300.0, opt=GasChromatographySystems.Options(), kwargs...)
-	sys = SplitSystem(Ls, ds, dfs, sps, TPs, Fs, pin, pout1, pout2; opt=opt, kwargs...)
+function SplitSystem(; Ls = [10.0, 1.0, 5.0], ds = [0.25, 0.1, 0.25], dfs = [0.25, 0.0, 0.0], sps = ["Rxi17SilMS", "", ""], TPs = [default_TP(), 300.0, 300.0], Fs = [1.0, NaN, NaN], pin = NaN, pout1 = 0.0, pout2 = 101300.0, name="SplitSystem", opt=GasChromatographySystems.Options(), kwargs...)
+	sys = SplitSystem(Ls, ds, dfs, sps, TPs, Fs, pin, pout1, pout2; name=name, opt=opt, kwargs...)
 	return sys
 end
 
 # definition GCxGC system with thermal modulator
-function GCxGC_TM(L1, d1, df1, sp1, TP1, L2, d2, df2, sp2, TP2, LTL, dTL, dfTL, spTL, TPTL, LM::Array{Float64,1}, dM, dfM, spM, shift, PM, ratioM, HotM, ColdM, TPM, F, pin, pout; opt=GasChromatographySystems.Options(), optTM=ModuleTMOptions(), optCol=ModuleColumnOptions())
+function GCxGC_TM(L1, d1, df1, sp1, TP1, L2, d2, df2, sp2, TP2, LTL, dTL, dfTL, spTL, TPTL, LM::Array{Float64,1}, dM, dfM, spM, shift, PM, ratioM, HotM, ColdM, TPM, F, pin, pout; name="GCxGC_TM", opt=GasChromatographySystems.Options(), optTM=ModuleTMOptions(), optCol=ModuleColumnOptions())
 
 	TPs = [TP1, TP2, TPM]
 	
@@ -162,12 +162,12 @@ function GCxGC_TM(L1, d1, df1, sp1, TP1, L2, d2, df2, sp2, TP2, LTL, dTL, dfTL, 
 	modules[7] = ModuleColumn("GC column 2", L2, d2*1e-3, df2*1e-6, sp2, TP2, NaN, optCol)
 	modules[8] = ModuleColumn("TL", LTL, dTL*1e-3, dfTL*1e-6, spTL, TPTL, NaN, optCol)
 	# system
-	sys = update_system(System(g, pp, modules, opt))
+	sys = update_system(System(name, g, pp, modules, opt))
 	return sys
 end
 
-function GCxGC_TM(; L1 = 30.0, d1 = 0.25, df1 = 0.25, sp1 = "ZB1ms", TP1 = default_TP(), L2 = 2.0, d2 = 0.1, df2 = 0.1, sp2 = "Stabilwax", TP2 = default_TP(), LTL = 0.25, dTL = 0.1, dfTL = 0.1, spTL = "Stabilwax", TPTL = 280.0, LM = [0.30, 0.01, 0.90, 0.01, 0.30], dM = 0.1, dfM = 0.1, spM = "Stabilwax", shift = 0.0, PM = 4.0, ratioM = 0.9125, HotM = 30.0, ColdM = -120.0, TPM = default_TP(), F = 0.8, pin = NaN, pout = 0.0, opt=GasChromatographySystems.Options(), optTM=ModuleTMOptions(), optCol=ModuleColumnOptions())
-	sys = GCxGC_TM(L1, d1, df1, sp1, TP1, L2, d2, df2, sp2, TP2, LTL, dTL, dfTL, spTL, TPTL, LM::Array{Float64,1}, dM, dfM, spM, shift, PM, ratioM, HotM, ColdM, TPM, F, pin, pout; opt=opt, optTM=optTM, optCol=optCol)
+function GCxGC_TM(; L1 = 30.0, d1 = 0.25, df1 = 0.25, sp1 = "ZB1ms", TP1 = default_TP(), L2 = 2.0, d2 = 0.1, df2 = 0.1, sp2 = "Stabilwax", TP2 = default_TP(), LTL = 0.25, dTL = 0.1, dfTL = 0.1, spTL = "Stabilwax", TPTL = 280.0, LM = [0.30, 0.01, 0.90, 0.01, 0.30], dM = 0.1, dfM = 0.1, spM = "Stabilwax", shift = 0.0, PM = 4.0, ratioM = 0.9125, HotM = 30.0, ColdM = -120.0, TPM = default_TP(), F = 0.8, pin = NaN, pout = 0.0, name="GCxGC_TM", opt=GasChromatographySystems.Options(), optTM=ModuleTMOptions(), optCol=ModuleColumnOptions())
+	sys = GCxGC_TM(L1, d1, df1, sp1, TP1, L2, d2, df2, sp2, TP2, LTL, dTL, dfTL, spTL, TPTL, LM::Array{Float64,1}, dM, dfM, spM, shift, PM, ratioM, HotM, ColdM, TPM, F, pin, pout; name=name, opt=opt, optTM=optTM, optCol=optCol)
 	return sys
 end
 # end - specific systems


### PR DESCRIPTION
The changes are breaking previous versions.
- added name to `System` structure
- plot functions using the build functions for the solutions for the unknown pressurepoints `p2fun`
- added functions for saving the build functions of the solutions for the unknown pressurepoints
- added `interpolate_pressure_functions()` using the `p2fun` function array
- added the option `mode` with default value `mode = λ` to several flow calculation functions
- added function for export of balance equations for Mathematica
- added function for import solution of balance equation from Mathematica
- added function to check and change if needed the usage of flow permeabilities or flow restrictions in the solutions
- changed the `save_build_pressure_squared_functions` to save the build function in a dictionary with additional information
- added function versions using `p2fun` for `graph_to_parameters()`, `positive_flow()`, `path_possible()` and `simulate_along_paths()` (these should bee used as default versions)