### PR TITLE
Update simplified tm

### DIFF
--- a/src/ThermalModulator.jl
+++ b/src/ThermalModulator.jl
@@ -59,7 +59,7 @@ function slicing(pl, PM, ratio, shift, par::GasChromatographySimulator.Parameter
 	init_t_end = (mod_number.(tR .+ nτ.*τR, shift, PM, ratio) .- 1).*PM .- totalshift 
 	# number of slices for every substance: 
  	n_slice = round.(Int, (init_t_end .- init_t_start)./PM .+ 1) 
-	println("slicing(): init_t_start=$(init_t_start)s, init_t_end=$(init_t_end)s, n_slice=$(n_slice).")
+	#println("slicing(): init_t_start=$(init_t_start)s, init_t_end=$(init_t_end)s, n_slice=$(n_slice).")
 	sub_TM_focussed = Array{GasChromatographySimulator.Substance}(undef, sum(n_slice))
 	A_focussed = Array{Float64}(undef, sum(n_slice))
 	#A_unfocussed = Array{Float64}(undef, sum(n_slice))
@@ -83,13 +83,13 @@ function slicing(pl, PM, ratio, shift, par::GasChromatographySimulator.Parameter
                 #prob_unfocussed = IntegralProblem(g, init_t_start[i]+(j-1)*PM+tcold, init_t_start[i]+(j-1)*PM+tcold+thot, p)
                 # all focussed:
                 domain = (init_t_start[i]+(j-1)*PM, init_t_start[i]+j*PM)
-                    println("domain: $(domain), i=$(i), j=$(j), type: $(typeof(domain))")
+                    #println("domain: $(domain), i=$(i), j=$(j), type: $(typeof(domain))")
                 prob_focussed = IntegralProblem(g, domain, p)
                     #println("prob_focussed: $(prob_focussed)")
                 A_focussed[ii] = solve(prob_focussed, QuadGKJL(); reltol = reltol, abstol = abstol).u * AR[i]
                 #A_unfocussed[ii] = solve(prob_unfocussed, QuadGKJL(); reltol = 1e-18, abstol = 1e-30).u * AR[i]
 			end
-            println("A_focussed[ii] = $(A_focussed[ii])")
+            #println("A_focussed[ii] = $(A_focussed[ii])")
 			CAS_par = [par.sub[i].CAS for i in 1:length(par.sub)]
 			i_sub = findfirst(pl.CAS[i] .== CAS_par)
 			sub_TM_focussed[ii] = GasChromatographySimulator.Substance(par.sub[i_sub].name, par.sub[i_sub].CAS, par.sub[i_sub].Tchar, par.sub[i_sub].θchar, par.sub[i_sub].ΔCp, par.sub[i_sub].φ₀, "s$(j)_"*pl.Annotations[i], par.sub[i_sub].Cag, t₀, τ₀[i])

--- a/src/ThermalModulator.jl
+++ b/src/ThermalModulator.jl
@@ -555,7 +555,7 @@ function simulate_ModuleTM(segment_par, segment_module, prev_peaklist; nτ=6, τ
 	end
 	new_segment_par, df_A = slicing(prev_peaklist, segment_module.PM, segment_module.ratio, segment_module.shift, segment_par; nτ=nτ, τ₀=τ₀, abstol=segment_module.opt.abstol, reltol=segment_module.opt.reltol, alg=segment_module.opt.alg)
 	if segment_module.opt.alg == "simplifiedTM"
-		peaklist, solutions = simplifiedTM_mod1(segment_module.T, new_segment_par, df_A, segment_module.PM, segment_module.ratio, segment_module.shift, segment_module.Thot)
+		peaklist, solutions = simplifiedTM(segment_module.T, new_segment_par, df_A, segment_module.PM, segment_module.ratio, segment_module.shift, segment_module.Thot)
 	elseif segment_module.opt.alg == "simplifiedTM2"
 		peaklist, solutions = simplifiedTM_mod2(segment_module.T, new_segment_par, df_A, segment_module.PM, segment_module.ratio, segment_module.shift, segment_module.Thot, segment_module.Tcold)
 	elseif segment_module.opt.alg == "simplifiedTM3"

--- a/src/ThermalModulator.jl
+++ b/src/ThermalModulator.jl
@@ -147,20 +147,16 @@ times, peak widths, and other chromatographic parameters for each modulated peak
      - Annotations: Peak annotations
      - A: Peak areas
   2. Array of solution tuples containing:
-     - t: Time points [0, column length]
+     - t: column position [0, column length]
      - u: Tuples of (time, variance) at start and end points
 
 # Notes
 - Assumes rectangular temperature modulation (instantaneous temperature changes)
-- Calculates retention times based on the start of the next hot phase
-- Calculates peak widths as time to flush the modulator once. Length divided by velocity of the substance.
-- Handles both constant and programmed temperature conditions
-- Includes resolution and separation calculations for adjacent peaks
-- Uses mod_number for consistent modulation period calculations
-- Temperature values are converted between °C and K as needed
+- Calculates retention times based on the start of the next hot phase with added peak width (time to flush out the peak)
+- Calculates peak widths from band width equal to the length of the modulator segment
+- using simulation results in similar values, but takes longer to calculate, see 'simplifiedTM_mod2' and 'simplifiedTM_mod3'
 """
 function simplifiedTM(T, par, df_A, PM, ratio, shift, Thot;)
-	# rectangular function is assumed -> does this work with a changed definition (start modulation with the hot jet)
 	tcold = PM*ratio
 	thot = PM*(1-ratio)
 	sort_df_A = sort(df_A, :t0)
@@ -170,9 +166,11 @@ function simplifiedTM(T, par, df_A, PM, ratio, shift, Thot;)
 	No = [parse(Int, split(sort_df_A.Annotations[x], " ")[end]) for x in 1:length(sort_df_A.Annotations)]
 	Name = sort_df_A.Name
 	CAS = sort_df_A.CAS
-	number_of_modulation = GasChromatographySystems.mod_number.(t₀, shift, PM, ratio)
-	tR = number_of_modulation .* PM .- (tcold - shift)  .- thot # time of the start of the next hot jet 
-	#println("simplifiedTM(): t₀ = $(t₀)s, tR = $(tR)s.")
+	number_of_modulation = mod_number.(t₀, shift, PM, ratio)
+	t_next_hot = number_of_modulation .* PM .- (tcold - shift) .- thot # time of the start of the next hot jet 
+	#println("simplifiedTM(): t₀ = $(t₀)s, t_next_hot = $(t_next_hot)s.")
+	
+	# TODO: add test if tstart is in the hot or cold phase
 
 	# using par.prog.T_itp can result in wrong temperatures at tR, because of rounding errors for Float64 in `mod()`-function inside the `therm_mod()`-function.
 	# take the temperature/temperature program defined for the module and add Thot 
@@ -182,36 +180,248 @@ function simplifiedTM(T, par, df_A, PM, ratio, shift, Thot;)
 	else
 		GasChromatographySimulator.temperature_interpolation(T.time_steps, T.temp_steps .+ Thot, T.gf, par.col.L)
 	end
-	TR = T_itp(par.col.L, tR) .- 273.15
-	kR = Array{Float64}(undef, length(tR))
-	uR = Array{Float64}(undef, length(tR))
-	τ₀ = Array{Float64}(undef, length(tR))
-	for i=1:length(tR)
+	TR = T_itp(par.col.L, t_next_hot) .- 273.15
+	kR = Array{Float64}(undef, length(t_next_hot))
+	uR = Array{Float64}(undef, length(t_next_hot))
+	τ₀ = Array{Float64}(undef, length(t_next_hot))
+	for i=1:length(t_next_hot)
 		i_sub = findfirst(Name[i] .== df_A.Name)
-		kR[i] = GasChromatographySimulator.retention_factor(par.col.L, tR[i], T_itp, par.col.d, par.col.df, par.sub[i_sub].Tchar, par.sub[i_sub].θchar, par.sub[i_sub].ΔCp, par.sub[i_sub].φ₀)
-		rM = GasChromatographySimulator.mobile_phase_residency(par.col.L, tR[i], T_itp, par.prog.Fpin_itp, par.prog.pout_itp, par.col.L, par.col.d, par.col.gas; ng=par.opt.ng, vis=par.opt.vis, control=par.opt.control)
+		kR[i] = GasChromatographySimulator.retention_factor(par.col.L, t_next_hot[i], T_itp, par.col.d, par.col.df, par.sub[i_sub].Tchar, par.sub[i_sub].θchar, par.sub[i_sub].ΔCp, par.sub[i_sub].φ₀)
+		rM = GasChromatographySimulator.mobile_phase_residency(par.col.L, t_next_hot[i], T_itp, par.prog.Fpin_itp, par.prog.pout_itp, par.col.L, par.col.d, par.col.gas; ng=par.opt.ng, vis=par.opt.vis, control=par.opt.control)
 		uR[i] = 1/(rM*(1+kR[i]))
 		τ₀[i] = par.sub[i_sub].τ₀
 	end
-	τR = par.col.L./uR
-	σR = uR./τR
+	σR = par.col.L
+	τR = σR./uR
 	Annotations = sort_df_A.Annotations
-	pl = sort!(DataFrame(No=No, Name=Name, CAS=CAS, tR=tR, τR=τR, TR=TR, σR=σR, uR=uR, kR=kR, Annotations=Annotations, A=A), [:tR])
-	Res = Array{Float64}(undef, length(tR))
-	Δs = Array{Float64}(undef, length(tR))
-	for i=1:(length(tR)-1)
+	pl = sort!(DataFrame(No=No, Name=Name, CAS=CAS, tR=t_next_hot+τR, τR=τR, TR=TR, σR=σR, uR=uR, kR=kR, Annotations=Annotations, A=A), [:tR])
+	Res = Array{Float64}(undef, length(t_next_hot))
+	Δs = Array{Float64}(undef, length(t_next_hot))
+	for i=1:(length(t_next_hot)-1)
 		Res[i] = (pl.tR[i+1] - pl.tR[i])/(2*(pl.τR[i+1] + pl.τR[i]))
         Δs[i] = (pl.tR[i+1] - pl.tR[i])/(pl.τR[i+1] - pl.τR[i]) * log(pl.τR[i+1]/pl.τR[i])
 	end
 	pl[!, :Res] = Res
 	pl[!, :Δs] = Δs
 
-	sol = Array{NamedTuple{(:t, :u), Tuple{Vector{Float64}, Vector{Tuple{Float64, Float64}}}}}(undef, length(tR))
-	for i=1:length(tR)
-		sol[i] = (t = [0.0, par.col.L], u = [(t₀[i], τ₀[i]), (tR[i], τR[i]^2)])
+	sol = Array{NamedTuple{(:t, :u), Tuple{Vector{Float64}, Vector{Tuple{Float64, Float64}}}}}(undef, length(t_next_hot))
+	for i=1:length(t_next_hot)
+		sol[i] = (t = [0.0, par.col.L], u = [(t₀[i], τ₀[i]), (t_next_hot[i] + τR[i], τR[i]^2)])
 	end
 	
 	return select(pl, [:No, :Name, :CAS, :tR, :τR, :TR, :σR, :uR, :kR, :Res, :Δs, :Annotations, :A]), sol
+end
+
+"""
+    simplifiedTM_mod2(T, par, df_A, PM, ratio, shift, Thot, Tcold)
+
+Estimate retention times and peak widths for thermal modulation by assuming isothermal conditions during cold and hot phases.
+
+This function uses a simplified approach that treats the cold and hot phases as separate isothermal conditions.
+It calculates retention times by:
+1. Determining the cold phase temperature (Tmin) based on whether Tcold is absolute or relative
+2. Creating separate temperature interpolation functions for cold and hot phases
+3. Calculating retention factors and holdup times for both phases
+4. Estimating the migration distance during cold phase
+5. Computing final retention times based on hot phase conditions
+
+# Arguments
+- `T`: Base temperature or temperature program for the column
+- `par`: Parameters structure containing column, program, and substance information
+- `df_A`: DataFrame containing peak areas and initial times
+- `PM`: Modulation period in seconds
+- `ratio`: Ratio of cold phase duration to total period (0 < ratio < 1)
+- `shift`: Time shift of the modulation pattern in seconds
+- `Thot`: Temperature difference for hot phase in °C
+- `Tcold`: Temperature difference for cold phase in °C (absolute or relative)
+
+# Returns
+- `peaklist`: DataFrame containing retention times and peak parameters
+- `solutions`: Solutions from the simulation
+- `T_itp_cold`: Temperature interpolation function for cold phase
+- `T_itp_hot`: Temperature interpolation function for hot phase
+
+# Notes
+- Assumes isothermal conditions during both cold and hot phases
+- Uses a simplified approach that may not capture all temperature transition effects
+- Calculates migration distance during cold phase to estimate peak positions
+- Performs a final simulation using cold phase conditions to verify results
+"""
+function simplifiedTM_mod2(T, par, df_A, PM, ratio, shift, Thot, Tcold;)
+	tcold = PM*ratio
+	thot = PM*(1-ratio)
+	sort_df_A = sort(df_A, :t0)
+	#println("simplifiedTM(): sort_df_A.t₀ = $(sort_df_A.t0)s.")
+	tstart = sort_df_A.t0 # no need to again calculate the time as it was already calculated with the slicing in df_A.t0
+	A = sort_df_A.A
+	No = [parse(Int, split(sort_df_A.Annotations[x], " ")[end]) for x in 1:length(sort_df_A.Annotations)]
+	Name = sort_df_A.Name
+	CAS = sort_df_A.CAS
+	number_of_modulation = mod_number.(tstart, shift, PM, ratio)
+	t_next_hot = number_of_modulation .* PM .- (tcold - shift) .- thot # time of the start of the next hot jet 
+	#println("simplifiedTM_mod2(): tstart = $(tstart)s, t_next_hot = $(t_next_hot)s.")
+
+	Tmin = if opt_values[2] == "absolut"
+		Tcold
+	else
+		T + Tcold
+	end
+	T_itp_cold = if typeof(T) <: Number
+		gf(x) = zero(x).*ones(2)
+		GasChromatographySimulator.temperature_interpolation([0.0, 3600.0], [Tmin, Tmin], gf, par.col.L)
+	else
+		GasChromatographySimulator.temperature_interpolation(T.time_steps, fill(Tmin, length(T.time_steps)), T.gf, par.col.L)
+	end
+	T_itp_hot = if typeof(T) <: Number
+		gf_(x) = zero(x).*ones(2)
+		GasChromatographySimulator.temperature_interpolation([0.0, 3600.0], [T + Thot, T + Thot], gf_, par.col.L)
+	else
+		GasChromatographySimulator.temperature_interpolation(T.time_steps, T.temp_steps .+ Thot, T.gf, par.col.L)
+	end
+
+	T_cold = T_itp_cold(par.col.L/2, tstart) .- 273.15
+	T_hot = T_itp_hot(par.col.L/2, t_next_hot) .- 273.15
+	#println("simplifiedTM_mod2(): T_cold = $(T_cold)°C, T_hot = $(T_hot)°C.")
+	tM_cold = Array{Float64}(undef, length(t_next_hot))
+	tM_hot = Array{Float64}(undef, length(t_next_hot))
+	k_cold = Array{Float64}(undef, length(t_next_hot))
+	k_hot = Array{Float64}(undef, length(t_next_hot))
+	x_cold = Array{Float64}(undef, length(t_next_hot))
+	for i=1:length(t_next_hot)
+		tM_cold[i] = GasChromatographySimulator.holdup_time(tstart[i], T_itp_cold, par.prog.Fpin_itp, par.prog.pout_itp, par.col.L, par.col.d, par.col.gas; ng=par.opt.ng, vis=par.opt.vis, control=par.opt.control)
+		tM_hot[i] = GasChromatographySimulator.holdup_time(t_next_hot[i], T_itp_hot, par.prog.Fpin_itp, par.prog.pout_itp, par.col.L, par.col.d, par.col.gas; ng=par.opt.ng, vis=par.opt.vis, control=par.opt.control)
+		i_sub = findfirst(Name[i] .== df_A.Name)
+		k_cold[i] = GasChromatographySimulator.retention_factor(par.col.L, tstart[i], T_itp_cold, par.col.d, par.col.df, par.sub[i_sub].Tchar, par.sub[i_sub].θchar, par.sub[i_sub].ΔCp, par.sub[i_sub].φ₀)
+		k_hot[i] = GasChromatographySimulator.retention_factor(par.col.L, t_next_hot[i], T_itp_hot, par.col.d, par.col.df, par.sub[i_sub].Tchar, par.sub[i_sub].θchar, par.sub[i_sub].ΔCp, par.sub[i_sub].φ₀)
+	end
+	#println("simplifiedTM_mod2(): tM_cold = $(tM_cold)s, tM_hot = $(tM_hot)s.")
+	#println("simplifiedTM_mod2(): k_cold = $(k_cold), k_hot = $(k_hot).")
+	# TODO: add this as separate function to test the focus effect:
+	x_cold = tcold./tM_cold*par.col.L./(1 .+ k_cold) # longer than L -> problem
+	#println("simplifiedTM_mod2(): x_cold = $(x_cold)m.")
+	tR_hot = tM_hot .* (1 .+ k_hot)
+	#println("simplifiedTM_mod2(): tR_hot = $(tR_hot)s.")
+	ttotal = t_next_hot .+ tR_hot
+	#println("simplifiedTM_mod2(): ttotal = $(ttotal)s.")
+#	try to simulate with t0 = tstart and temperature T_itp_cold -> tR should be much bigger than t_next_hot otherwise we would have breaktrough
+	new_segment_par = GasChromatographySystems.change_initial(par, tstart, fill(tcold, length(par.sub)))
+	Name = [new_segment_par.sub[i].name for i=1:length(new_segment_par.sub)]
+	CAS = [new_segment_par.sub[i].CAS for i=1:length(new_segment_par.sub)]
+	ann = [new_segment_par.sub[i].ann for i=1:length(new_segment_par.sub)]
+	Tchar = [new_segment_par.sub[i].Tchar for i=1:length(new_segment_par.sub)]
+	θchar = [new_segment_par.sub[i].θchar for i=1:length(new_segment_par.sub)]
+	ΔCp = [new_segment_par.sub[i].ΔCp for i=1:length(new_segment_par.sub)]
+	φ₀ = [new_segment_par.sub[i].φ₀ for i=1:length(new_segment_par.sub)]
+	Cag = [new_segment_par.sub[i].Cag for i=1:length(new_segment_par.sub)]
+	#t₀ = [new_segment_par.sub[i].Tchar for i=1:length(new_segment_par.sub)]
+	#τ₀ = [new_segment_par.sub[i].Tchar for i=1:length(new_segment_par.sub)]
+	peaklist, solutions = GasChromatographySimulator.simulate(par.col.L, par.col.d, par.col.df, par.col.gas, T_itp_cold, par.prog.Fpin_itp, par.prog.pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, Cag, tstart, fill(tcold, length(par.sub)), new_segment_par.opt)
+	# No. is not assigned 
+	No = [parse(Int, split(ann[i], ", No: ")[end]) for i=1:length(ann)]
+	peaklist[!, "No"] = No
+	GasChromatographySystems.add_A_to_pl!(peaklist, df_A)
+	return peaklist, solutions, T_itp_cold, T_itp_hot
+	#GasChromatographySimulator.solve_system(par.col.L, par.col.d, par.col.df, par.col.gas, T_itp_cold, par.prog.Fpin_itp, par.prog.pout_itp, Tchar, θchar, ΔCp, φ₀, Cag, tstart, fill(tcold, length(par.sub)), new_segment_par.opt)
+end
+
+"""
+    simplifiedTM_mod3(T, par, df_A, PM, ratio, shift, Thot)
+
+Estimate retention times and peak widths for thermal modulation by simulating from the hot phase start.
+
+This function uses a more detailed approach that:
+1. Determines whether peaks arrive during cold or hot phase
+2. Adjusts initial conditions based on arrival phase
+3. Uses a simplified temperature profile using hot phase conditions
+4. Performs a full simulation to calculate retention times and peak widths
+
+# Arguments
+- `T`: Base temperature or temperature program for the column
+- `par`: Parameters structure containing column, program, and substance information
+- `df_A`: DataFrame containing peak areas and initial times from slicing
+- `PM`: Modulation period in seconds
+- `ratio`: Ratio of cold phase duration to total period (0 < ratio < 1)
+- `shift`: Time shift of the modulation pattern in seconds
+- `Thot`: Temperature difference for hot phase in °C
+
+# Returns
+- `peaklist`: DataFrame containing retention times and peak parameters
+- `solutions`: Solutions from the simulation
+
+# Notes
+- Assumes rectangular temperature modulation pattern
+- Adjusts initial conditions based on whether peaks arrive during cold or hot phase
+- Uses a simplified temperature profile to avoid ODE solver issues
+- Provides more accurate results than simplifiedTM_mod2 but takes longer to compute
+- Issues warnings for peaks that arrive during hot phase
+"""
+function simplifiedTM_mod3(T, par, df_A, PM, ratio, shift, Thot;)
+	# rectangular function is assumed -> does this work with a changed definition (start modulation with the hot jet)
+	tcold = PM*ratio
+	thot = PM*(1-ratio)
+	sort_df_A = sort(df_A, :t0)
+	#println("simplifiedTM(): sort_df_A.t₀ = $(sort_df_A.t0)s.")
+	# rename t₀ to tstart
+	# check if tstart during hotjet or coldjet
+	# if during hotjet -> t₀ = tstart and τ₀=τR prev segment (+ warning); if during coldjet t₀ = start of next hotjet and τ₀ = tcoldremain*(1+k(Thot)/(1+k(Tcold))); tcoldremain -> from tstart the remaining time of the cold jet
+	# 
+	tstart = sort_df_A.t0 # start time taken from slicing, if slicing happend than it should be at the start of a cold jet; if not it should be the retention time of the previous segment
+	A = sort_df_A.A
+	# do we need 'No', 'Name', 'CAS'? 
+	No = [parse(Int, split(sort_df_A.Annotations[x], " ")[end]) for x in 1:length(sort_df_A.Annotations)]
+	Name = sort_df_A.Name
+	CAS = sort_df_A.CAS
+	# in which modulation are we in and in which phase (cold/hot jet)
+	number_of_modulation = mod_number.(tstart, shift, PM, ratio)
+	t_next_hot = number_of_modulation .* PM .- (tcold - shift) .- thot # time of the start of the next hot jet 
+	#println("simplifiedTM(): tstart = $(tstart)s, t_next_hot = $(t_next_hot)s.")
+	t₀ = Array{Float64}(undef, length(tstart))
+	for i=1:length(tstart)
+		if tstart[i] - t_next_hot[i] <= tcold
+			t₀[i] = t_next_hot[i] # but it could be that the substance already migrates during cold jet
+		else # peak arrives during hot jet
+			t₀[i] = tstart[i]
+			@warn "Peak $(i), $(Name[i]) arrives during hot jet." 
+		end
+	end
+		
+	# using par.prog.T_itp can result in wrong temperatures at tR, because of rounding errors for Float64 in `mod()`-function inside the `therm_mod()`-function.
+	# take the temperature/temperature program defined for the module and add Thot 
+	# use this for simulation, as the rectangle function can lead to problems with the ODE solver
+	T_itp = if typeof(T) <: Number
+		gf(x) = zero(x).*ones(2)
+		GasChromatographySimulator.temperature_interpolation([0.0, 3600.0], [T + Thot, T + Thot], gf, par.col.L)
+	else
+		GasChromatographySimulator.temperature_interpolation(T.time_steps, T.temp_steps .+ Thot, T.gf, par.col.L)
+	end
+	
+	u0hot = Array{Float64}(undef, length(t₀))
+	for i=1:length(t₀)
+		i_sub = findfirst(Name[i] .== df_A.Name)
+		kR = GasChromatographySimulator.retention_factor(par.col.L, t₀[i], T_itp, par.col.d, par.col.df, par.sub[i_sub].Tchar, par.sub[i_sub].θchar, par.sub[i_sub].ΔCp, par.sub[i_sub].φ₀)
+		rM = GasChromatographySimulator.mobile_phase_residency(par.col.L, t₀[i], T_itp, par.prog.Fpin_itp, par.prog.pout_itp, par.col.L, par.col.d, par.col.gas; ng=par.opt.ng, vis=par.opt.vis, control=par.opt.control)
+		u0hot[i] = 1/(rM*(1+kR))
+	end
+	τ0hot = par.col.L./u0hot
+	#println("simplifiedTM(): τ0hot = $(τ0hot)s.")
+
+	new_segment_par = GasChromatographySystems.change_initial(par, t₀, τ0hot)
+	Name = [new_segment_par.sub[i].name for i=1:length(new_segment_par.sub)]
+	CAS = [new_segment_par.sub[i].CAS for i=1:length(new_segment_par.sub)]
+	ann = [new_segment_par.sub[i].ann for i=1:length(new_segment_par.sub)]
+	Tchar = [new_segment_par.sub[i].Tchar for i=1:length(new_segment_par.sub)]
+	θchar = [new_segment_par.sub[i].θchar for i=1:length(new_segment_par.sub)]
+	ΔCp = [new_segment_par.sub[i].ΔCp for i=1:length(new_segment_par.sub)]
+	φ₀ = [new_segment_par.sub[i].φ₀ for i=1:length(new_segment_par.sub)]
+	Cag = [new_segment_par.sub[i].Cag for i=1:length(new_segment_par.sub)]
+	#t₀ = [new_segment_par.sub[i].Tchar for i=1:length(new_segment_par.sub)]
+	#τ₀ = [new_segment_par.sub[i].Tchar for i=1:length(new_segment_par.sub)]
+	peaklist, solutions = GasChromatographySimulator.simulate(par.col.L, par.col.d, par.col.df, par.col.gas, T_itp, par.prog.Fpin_itp, par.prog.pout_itp, Name, CAS, ann, Tchar, θchar, ΔCp, φ₀, Cag, t₀, τ0hot, new_segment_par.opt)
+	# No. is not assigned 
+	No = [parse(Int, split(ann[i], ", No: ")[end]) for i=1:length(ann)]
+	peaklist[!, "No"] = No
+	GasChromatographySystems.add_A_to_pl!(peaklist, df_A)
+	return peaklist, solutions
 end
 
 """
@@ -257,15 +467,22 @@ function simulate_ModuleTM(segment_par, segment_module, prev_peaklist; nτ=6, τ
 	end
 	new_segment_par, df_A = slicing(prev_peaklist, segment_module.PM, segment_module.ratio, segment_module.shift, segment_par; nτ=nτ, τ₀=τ₀, abstol=segment_module.opt.abstol, reltol=segment_module.opt.reltol, alg=segment_module.opt.alg)
 	if segment_module.opt.alg == "simplifiedTM"
-		peaklist, solutions = simplifiedTM(segment_module.T, new_segment_par, df_A, segment_module.PM, segment_module.ratio, segment_module.shift, segment_module.Thot)
+		peaklist, solutions = simplifiedTM_mod1(segment_module.T, new_segment_par, df_A, segment_module.PM, segment_module.ratio, segment_module.shift, segment_module.Thot)
+	elseif segment_module.opt.alg == "simplifiedTM2"
+		peaklist, solutions = simplifiedTM_mod2(segment_module.T, new_segment_par, df_A, segment_module.PM, segment_module.ratio, segment_module.shift, segment_module.Thot, segment_module.Tcold)
+	elseif segment_module.opt.alg == "simplifiedTM3"
+		peaklist, solutions = simplifiedTM_mod3(segment_module.T, new_segment_par, df_A, segment_module.PM, segment_module.ratio, segment_module.shift, segment_module.Thot)
 	else # not tested
 		sol = Array{Any}(undef, length(new_segment_par.sub))
 		for i_sub=1:length(new_segment_par.sub)
 			dt = segment_module.opt.dtinit
 			sol[i_sub] = GasChromatographySimulator.solving_odesystem_r(new_segment_par.col, new_segment_par.prog, new_segment_par.sub[i_sub], new_segment_par.opt; kwargsTM..., dt=dt)
 			tR = sol[i_sub].u[end][1]
-			# replace fld() with mod_number() and fix shift to total shift
-			while (fld(tR + segment_module.shift, segment_module.PM) > fld(new_segment_par.sub[i_sub].t₀ + segment_module.shift, segment_module.PM) && dt > eps()) || (sol[i_sub].retcode != ReturnCode.Success && dt > eps()) # solute elutes not in the same modulation periode or the solving failed
+			# Replace fld-based comparison with mod_number
+			while (mod_number(tR, segment_module.shift, segment_module.PM, segment_module.ratio) > 
+				   mod_number(new_segment_par.sub[i_sub].t₀, segment_module.shift, segment_module.PM, segment_module.ratio) && 
+				   dt > eps()) || 
+				  (sol[i_sub].retcode != ReturnCode.Success && dt > eps()) # solute elutes not in the same modulation periode or the solving failed
 				dt = dt/10 # reduce initial step-width
 				dtmax = dt*1000
 				@warn "Retention time $(tR) surpasses modulation period, t₀ = $(new_segment_par.sub[i_sub].t₀), PM = $(segment_module.PM). Initial step-width dt is decreased ($(dt))."


### PR DESCRIPTION
- updated simplifiedTM function
- added simplifiedTM_mod2 function and simplifiedTM_mod3
- updated simulate_ModuleTM function for the three options of simplifiedTM, simplifiedTM_mod2 and simplifiedTM_mod3
- commenting out outputs in slicing function
- function 'modulator_phase' to determine in which phase of the modulator (hot or cold jet) does the start time falls
- function 'check_retention_cold_jet' to check, if the analyte is retained during cold jet by (isothermal) estimation of the distance it migrates during the cold jet, if this distance is smaller than the length of the modulator, it is assumed retained